### PR TITLE
Fix wrong mock return value on cp test

### DIFF
--- a/test/units/modules/network/check_point/test_cp_mgmt_access_role.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_access_role.py
@@ -97,7 +97,7 @@ class TestCheckpointAccessRole(object):
 
     def test_update_idempotent(self, mocker, connection_mock):
         mock_function = mocker.patch(function_path)
-        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
         connection_mock.send_request.return_value = (200, OBJECT)
         result = self._run_module(UPDATE_PAYLOAD)
 


### PR DESCRIPTION
##### SUMMARY
Fix wrong mock return value on cp test

This PR fixes a wrong mock return value on test_cp_mgmt_acces_role, which
fails on the assertion as a result.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/units/modules/network/check_point/test_cp_mgmt_access_role.py